### PR TITLE
Fix libvlc files included in resources when packaging UWP app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,6 @@ jobs:
         with:
           name: libvlc-uwp
           path: '*.nupkg'
-      - name: Push to GitHub Packages
+      - name: Push to Nuget
         if: github.event_name == 'push'
         run: nuget push *.nupkg -Source "https://api.nuget.org/v3/index.json" -ApiKey ${{ secrets.NUGET_TOKEN }} -SkipDuplicate

--- a/VideoLAN.LibVLC.UWP.nuspec
+++ b/VideoLAN.LibVLC.UWP.nuspec
@@ -16,27 +16,11 @@
   </metadata>
   <files>
     <!-- https://code.videolan.org/videolan/vlc/-/commit/c900a2183f8988f32e60afdcae3aa398387295f1 -->
-    <!-- <file src="build\LibVLC.UWP.targets" target="build"/> -->
-    <file src="build\win10-x86\native\plugins\**" target="runtimes\win10-x86\native\plugins"/>
-    <file src="build\win10-x86\native\sdk\**" target="runtimes\win10-x86\native\sdk"/>
-    <file src="build\win10-x86\native\lua\**" target="runtimes\win10-x86\native\lua"/>
-    <file src="build\win10-x86\native\libvlc*.*" target="runtimes\win10-x86\native"/>
-
-    <file src="build\win10-x64\native\plugins\**" target="runtimes\win10-x64\native\plugins"/>
-    <file src="build\win10-x64\native\sdk\**" target="runtimes\win10-x64\native\sdk"/>
-    <file src="build\win10-x64\native\lua\**" target="runtimes\win10-x64\native\lua"/>
-    <file src="build\win10-x64\native\libvlc*.*" target="runtimes\win10-x64\native"/>
-
-    <file src="build\win10-arm\native\plugins\**" target="runtimes\win10-arm\native\plugins"/>
-    <file src="build\win10-arm\native\sdk\**" target="runtimes\win10-arm\native\sdk"/>
-    <file src="build\win10-arm\native\lua\**" target="runtimes\win10-arm\native\lua"/>
-    <file src="build\win10-arm\native\libvlc*.*" target="runtimes\win10-arm\native"/>
-
-    <file src="build\win10-arm64\native\plugins\**" target="runtimes\win10-arm64\native\plugins"/>
-    <file src="build\win10-arm64\native\sdk\**" target="runtimes\win10-arm64\native\sdk"/>
-    <file src="build\win10-arm64\native\lua\**" target="runtimes\win10-arm64\native\lua"/>
-    <file src="build\win10-arm64\native\libvlc*.*" target="runtimes\win10-arm64\native"/>
-
+    <file src="build\LibVLC.UWP.targets" target="build"/>
+    <file src="build\win10-x86\native\**" target="build\win10-x86"/>
+    <file src="build\win10-x64\native\**" target="build\win10-x64"/>
+    <file src="build\win10-arm\native\**" target="build\win10-arm"/>
+    <file src="build\win10-arm64\native\**" target="build\win10-arm64"/>
     <file src="icon.png" target="" />
   </files>
 </package>

--- a/VideoLAN.LibVLC.UWP.nuspec
+++ b/VideoLAN.LibVLC.UWP.nuspec
@@ -16,11 +16,27 @@
   </metadata>
   <files>
     <!-- https://code.videolan.org/videolan/vlc/-/commit/c900a2183f8988f32e60afdcae3aa398387295f1 -->
-    <file src="build\LibVLC.UWP.targets" target="build\LibVLC.UWP.targets"/>
-    <file src="build\win10-x86\native\**" target="build\win10-x86"/>
-    <file src="build\win10-x64\native\**" target="build\win10-x64"/>
-    <file src="build\win10-arm\native\**" target="build\win10-arm"/>
-    <file src="build\win10-arm64\native\**" target="build\win10-arm64"/>
+    <!-- <file src="build\LibVLC.UWP.targets" target="build"/> -->
+    <file src="build\win10-x86\native\plugins\**" target="runtimes\win10-x86\native\plugins"/>
+    <file src="build\win10-x86\native\sdk\**" target="runtimes\win10-x86\native\sdk"/>
+    <file src="build\win10-x86\native\lua\**" target="runtimes\win10-x86\native\lua"/>
+    <file src="build\win10-x86\native\libvlc*.*" target="runtimes\win10-x86\native"/>
+
+    <file src="build\win10-x64\native\plugins\**" target="runtimes\win10-x64\native\plugins"/>
+    <file src="build\win10-x64\native\sdk\**" target="runtimes\win10-x64\native\sdk"/>
+    <file src="build\win10-x64\native\lua\**" target="runtimes\win10-x64\native\lua"/>
+    <file src="build\win10-x64\native\libvlc*.*" target="runtimes\win10-x64\native"/>
+
+    <file src="build\win10-arm\native\plugins\**" target="runtimes\win10-arm\native\plugins"/>
+    <file src="build\win10-arm\native\sdk\**" target="runtimes\win10-arm\native\sdk"/>
+    <file src="build\win10-arm\native\lua\**" target="runtimes\win10-arm\native\lua"/>
+    <file src="build\win10-arm\native\libvlc*.*" target="runtimes\win10-arm\native"/>
+
+    <file src="build\win10-arm64\native\plugins\**" target="runtimes\win10-arm64\native\plugins"/>
+    <file src="build\win10-arm64\native\sdk\**" target="runtimes\win10-arm64\native\sdk"/>
+    <file src="build\win10-arm64\native\lua\**" target="runtimes\win10-arm64\native\lua"/>
+    <file src="build\win10-arm64\native\libvlc*.*" target="runtimes\win10-arm64\native"/>
+
     <file src="icon.png" target="" />
   </files>
 </package>

--- a/build/LibVLC.UWP.targets
+++ b/build/LibVLC.UWP.targets
@@ -1,18 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <VlcUWPX64Enabled Condition="'$(VlcUWPX64Enabled)' == '' AND ('$(Platform)' == 'x64' OR '$(Platform)' == 'AnyCPU')">true</VlcUWPX64Enabled>
-    <VlcUWPX86Enabled Condition="'$(VlcUWPX86Enabled)' == '' AND ('$(Platform)' == 'x86' OR '$(Platform)' == 'AnyCPU')">true</VlcUWPX86Enabled>
-    <VlcUWPARMEnabled Condition="'$(VlcUWPARMEnabled)' == '' AND ('$(Platform)' == 'ARM')">true</VlcUWPARMEnabled>
-    <VlcUWPARM64Enabled Condition="'$(VlcUWPARM64Enabled)' == '' AND ('$(Platform)' == 'ARM64')">true</VlcUWPARM64Enabled>
-  </PropertyGroup>
-
   <ItemGroup>
-    <!-- If no VlcWindows[...]IncludeFiles was declared previously, include all plugins by default by specifying ** (escaped, so %2A%2A) -->
-    <VlcUWPX64IncludeFiles Condition="'@(VlcUWPX64IncludeFiles)'==''" Include="libvlc.%2A;libvlccore.%2A;hrtfs\%2A%2A;locale\%2A%2A;lua\%2A%2A;plugins\%2A%2A" />
-    <VlcUWPX86IncludeFiles Condition="'@(VlcUWPX86IncludeFiles)'==''" Include="libvlc.%2A;libvlccore.%2A;hrtfs\%2A%2A;locale\%2A%2A;lua\%2A%2A;plugins\%2A%2A" />
-    <VlcUWPARMIncludeFiles Condition="'@(VlcUWPARMIncludeFiles)'==''" Include="libvlc.%2A;libvlccore.%2A;hrtfs\%2A%2A;locale\%2A%2A;lua\%2A%2A;plugins\%2A%2A" />
-    <VlcUWPARM64IncludeFiles Condition="'@(VlcUWPARM64IncludeFiles)'==''" Include="libvlc.%2A;libvlccore.%2A;hrtfs\%2A%2A;locale\%2A%2A;lua\%2A%2A;plugins\%2A%2A" />
+    <VlcUWPX64IncludeFilesFullPath Include="$(MSBuildThisFileDirectory)win10-x64\**" />
+    <VlcUWPX86IncludeFilesFullPath Include="$(MSBuildThisFileDirectory)win10-x86\**" />
+    <VlcUWPARMIncludeFilesFullPath Include="$(MSBuildThisFileDirectory)win10-arm\**" />
+    <VlcUWPARM64IncludeFilesFullPath Include="$(MSBuildThisFileDirectory)win10-arm64\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,66 +14,22 @@
     </SDKReference>
   </ItemGroup>
 
-  <Target Name="CollectVlcFilesToCopyUWP" BeforeTargets="BeforeBuild">
-    <!-- We need a target in order to make batching work -->
-    <!-- Some useful links to understand how it works:
-      http://sedotech.com/Resources#Batching (4 parts of excellent explanation of Batching. Link 2 is dead, but can be found in parts 3 and above)
-      http://sedodream.com/2010/10/21/MSBuildFilterListTake2.aspx
-    -->
-
-    <!-- First, transform the escaped, relative, platform-independant file path into real path, relative to 32/64 folders -->
-
-    <!-- x64 -->
-    <ItemGroup Condition="'$(VlcUWPX64Enabled)' == 'true'">
-      <!-- Expand selectors and compute absolute paths for include, exclude and MainLibraries -->
-      <VlcUWPX64IncludeFilesFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\win10-x64\%(VlcUWPX64IncludeFiles.Identity)))" />
-      <VlcUWPX64ExcludeFilesFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\win10-x64\%(VlcUWPX64ExcludeFiles.Identity)))" 
-        Condition="'%(VlcUWPX64ExcludeFiles.Identity)'!=''" />
-
-      <!-- We have gathered all the full path of what should be copied and what should be skipped, let's include that as Content that gets copied -->
-      <Content Include="@(VlcUWPX64IncludeFilesFullPath)" Exclude="@(VlcUWPX64ExcludeFilesFullPath)">
-        <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\win10-x64\, %(FullPath)))</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
-
-    <!-- x86 -->
-    <ItemGroup Condition="'$(VlcUWPX86Enabled)' == 'true'">
-      <!-- Expand selectors and compute absolute paths for include, exclude and MainLibraries -->
-      <VlcUWPX86IncludeFilesFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\win10-x86\%(VlcUWPX86IncludeFiles.Identity)))" />
-      <VlcUWPX86ExcludeFilesFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\win10-x86\%(VlcUWPX86ExcludeFiles.Identity)))" Condition="'%(VlcWindowsX86ExcludeFiles.Identity)'!=''" />
-
-      <!-- We have gathered all the full path of what should be copied and what should be skipped, let's include that as Content that gets copied -->
-      <Content Include="@(VlcUWPX86IncludeFilesFullPath)" Exclude="@(VlcUWPX86ExcludeFilesFullPath)">
-        <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\win10-x86\, %(FullPath)))</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
-
-     <!-- ARM -->
-    <ItemGroup Condition="'$(VlcUWPARMEnabled)' == 'true'">
-      <!-- Expand selectors and compute absolute paths for include, exclude and MainLibraries -->
-      <VlcUWPARMIncludeFilesFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\win10-arm\%(VlcUWPARMIncludeFiles.Identity)))" />
-      <VlcUWPARMExcludeFilesFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\win10-arm\%(VlcUWPARMExcludeFiles.Identity)))" Condition="'%(VlcWindowsARMExcludeFiles.Identity)'!=''" />
-
-      <!-- We have gathered all the full path of what should be copied and what should be skipped, let's include that as Content that gets copied -->
-      <Content Include="@(VlcUWPARMIncludeFilesFullPath)" Exclude="@(VlcUWPARMExcludeFilesFullPath)">
-        <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\win10-arm\, %(FullPath)))</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
-
-    <!-- ARM64 -->
-    <ItemGroup Condition="'$(VlcUWPARM64Enabled)' == 'true'">
-      <!-- Expand selectors and compute absolute paths for include, exclude and MainLibraries -->
-      <VlcUWPARM64IncludeFilesFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\win10-arm64\%(VlcUWPARM64IncludeFiles.Identity)))" />
-      <VlcUWPARM64ExcludeFilesFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\win10-arm64\%(VlcUWPARM64ExcludeFiles.Identity)))" Condition="'%(VlcWindowsARM64ExcludeFiles.Identity)'!=''" />
-
-      <!-- We have gathered all the full path of what should be copied and what should be skipped, let's include that as Content that gets copied -->
-      <Content Include="@(VlcUWPARM64IncludeFilesFullPath)" Exclude="@(VlcUWPARM64ExcludeFilesFullPath)">
-        <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\win10-arm64\, %(FullPath)))</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
-  </Target>
+  <ItemGroup>
+    <None Condition="'$(Platform)' == 'x64'" Include="@(VlcUWPX64IncludeFilesFullPath)">
+      <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)win10-x64\, %(FullPath)))</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Condition="'$(Platform)' == 'x86'" Include="@(VlcUWPX86IncludeFilesFullPath)">
+      <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)win10-x86\, %(FullPath)))</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Condition="'$(Platform)' == 'ARM'" Include="@(VlcUWPARMIncludeFilesFullPath)">
+      <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)win10-arm\, %(FullPath)))</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Condition="'$(Platform)' == 'ARM64'" Include="@(VlcUWPARM64IncludeFilesFullPath)">
+      <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)win10-arm64\, %(FullPath)))</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Don't include libvlc files as `Content` items. Content files are considered resources and will be indexed by the UWP project on build. Since we use different DLLs for different architectures, the resource list for each platform will be different. This causes an issue for a bundled UWP package. Include libvlc files as `None` items instead.